### PR TITLE
Added exportCSV and exportTable

### DIFF
--- a/src/table-editor.ts
+++ b/src/table-editor.ts
@@ -1122,7 +1122,7 @@ export class TableEditor {
    * @param func - A function that does some operation on table information obtained by
    * {@link TableEditor#_findTable}.
    */
-  private withCompletedTable<T>(
+  public withCompletedTable<T>(
     options: Options,
     func: (tableInfo: TableInfo) => T,
   ): T | undefined {

--- a/src/table-editor.ts
+++ b/src/table-editor.ts
@@ -1117,12 +1117,25 @@ export class TableEditor {
   }
 
   /**
+   * Exports the table as a two dimensional string array
+   */
+  public exportTable(options: Options): string[][] | undefined {
+    return this.withCompletedTable(
+      options,
+      ({ range, lines, formulaLines, table, focus }: TableInfo) => {
+        const bodyRows = table.getRows();
+        return bodyRows.map(row=>row.getCells().map(cell=>cell.content));
+      },
+    );
+  }
+
+  /**
    * Finds a table, completes it, then does an operation with it.
    *
    * @param func - A function that does some operation on table information obtained by
    * {@link TableEditor#_findTable}.
    */
-  public withCompletedTable<T>(
+  private withCompletedTable<T>(
     options: Options,
     func: (tableInfo: TableInfo) => T,
   ): T | undefined {

--- a/src/table-editor.ts
+++ b/src/table-editor.ts
@@ -1119,14 +1119,26 @@ export class TableEditor {
   /**
    * Exports the table as a two dimensional string array
    */
-  public exportTable(options: Options): string[][] | undefined {
+  public exportTable(withtHeaders:boolean, options: Options): string[][] | undefined {
     return this.withCompletedTable(
       options,
       ({ range, lines, formulaLines, table, focus }: TableInfo) => {
         const bodyRows = table.getRows();
+        if(bodyRows.length > 0 && !withtHeaders) {
+          bodyRows.splice(0, 2);
+        }
+        // else if(bodyRows.length > 1) bodyRows.splice(1, 1);
         return bodyRows.map(row=>row.getCells().map(cell=>cell.content));
       },
     );
+  }
+
+  /**
+   * Exports the table as a two dimensional string array
+   */
+  public exportCSV(withtHeaders:boolean, options: Options): string | undefined {
+    const r = this.exportTable(withtHeaders, options);
+    return !r ? undefined : r.map(row=>row.join('\t')).join('\n');
   }
 
   /**

--- a/test/table-editor.ts
+++ b/test/table-editor.ts
@@ -5538,21 +5538,65 @@ describe('TableEditor', () => {
   /**
    * @test {TableEditor#exportTable}
    */
-  describe('#_updateLines(startRow, endRow, newLines, oldLines = undefined)', () => {
-    it('should update lines in the specified range', () => {
+  describe('#exportTable(withHeader, defaultOptions)', () => {
+    it('should export out the grid as two dimensional array with headers', () => {
       {
         const textEditor = new TextEditor([
           '| A   | B   |',
-          '| --- | --- |',
           '| C   | D   |',
           '| E   | F   |'
         ]);
         const tableEditor = new TableEditor(textEditor);
-        const result = tableEditor.exportTable(defaultOptions);
-        expect(result).to.be.equal([['A', 'B'], ['C', 'D'], ['E', 'F']]);
+        const result = tableEditor.exportTable(true, defaultOptions);
+        expect(result).to.be.eql([['A', 'B'], ['---', '---'], ['C', 'D'], ['E', 'F']]);
+      }
+    })
+
+    it('should export out the grid as two dimensional array without headers', () => {
+      {
+        const textEditor = new TextEditor([
+          '| A   | B   |',
+          '| C   | D   |',
+          '| E   | F   |'
+        ]);
+        const tableEditor = new TableEditor(textEditor);
+        const result = tableEditor.exportTable(false, defaultOptions);
+        expect(result).to.be.eql([['C', 'D'], ['E', 'F']]);
       }
     })
   });
+
+   /**
+   * @test {TableEditor#exportCSV}
+   */
+  describe('#exportCSV(withHeader, defaultOptions)', () => {
+    it('should export out the grid as two dimensional array with headers', () => {
+      {
+        const textEditor = new TextEditor([
+          '| A   | B   |',
+          '| C   | D   |',
+          '| E   | F   |'
+        ]);
+        const tableEditor = new TableEditor(textEditor);
+        const result = tableEditor.exportCSV(true, defaultOptions);
+        expect(result).to.be.eql('A\tB\n---\t---\nC\tD\nE\tF');
+      }
+    })
+
+    it('should export out the grid as two dimensional array without headers', () => {
+      {
+        const textEditor = new TextEditor([
+          '| A   | B   |',
+          '| C   | D   |',
+          '| E   | F   |'
+        ]);
+        const tableEditor = new TableEditor(textEditor);
+        const result = tableEditor.exportCSV(false, defaultOptions);
+        expect(result).to.be.eql('C\tD\nE\tF');
+      }
+    })
+  });
+
   /**
    * @test {TableEditor#formatAll}
    */

--- a/test/table-editor.ts
+++ b/test/table-editor.ts
@@ -5536,6 +5536,24 @@ describe('TableEditor', () => {
   });
 
   /**
+   * @test {TableEditor#exportTable}
+   */
+  describe('#_updateLines(startRow, endRow, newLines, oldLines = undefined)', () => {
+    it('should update lines in the specified range', () => {
+      {
+        const textEditor = new TextEditor([
+          '| A   | B   |',
+          '| --- | --- |',
+          '| C   | D   |',
+          '| E   | F   |'
+        ]);
+        const tableEditor = new TableEditor(textEditor);
+        const result = tableEditor.exportTable(defaultOptions);
+        expect(result).to.be.equal([['A', 'B'], ['C', 'D'], ['E', 'F']]);
+      }
+    })
+  });
+  /**
    * @test {TableEditor#formatAll}
    */
   describe('#formatAll(options)', () => {


### PR DESCRIPTION
I've added two new methods to the `md-advanced-tables` to export either a raw two dimensional array and a method to straight export a CSV in the most common format used by most spreadsheets (tab spaces cells and newlines between rows).