### PR TITLE
Initial transpose table (#22)

### DIFF
--- a/test/table-editor.ts
+++ b/test/table-editor.ts
@@ -4629,6 +4629,38 @@ describe('TableEditor', () => {
   });
 
   /**
+   * @test {TableEditor#transpose}
+   */
+   describe('#transpose()', () => {
+    it('should transpose X and Y of a table (including headers), formatted the same.', () => {
+      {
+        const textEditor = new TextEditor([
+          'foo',
+          '| A   | B   |',
+          '| --- | --- |',
+          '| 1   | 2   |',
+          '| 3   | 4   |',
+          'bar',
+        ]);
+        textEditor.setCursorPosition(new Point(3,1));
+        const tableEditor = new TableEditor(textEditor);
+        tableEditor.transpose(defaultOptions);
+        const pos = textEditor.getCursorPosition();
+        // expect(pos.row).to.equal(3);
+        // expect(pos.column).to.equal(2);
+        // expect(textEditor.getSelectionRange()).to.be.undefined;
+        expect(textEditor.getLines()).to.deep.equal([
+          'foo',
+          '| A   | 1   | 3   |',
+          '| --- | --- | --- |',
+          '| B   | 2   | 4   |',
+          'bar',
+        ]);
+      }
+    })
+  });
+
+  /**
    * @test {TableEditor#sortRows}
    */
   describe('#sortRows(sortOrder)', () => {


### PR DESCRIPTION
@tgrosinger it's definitely not the prettiest code (due to the need to ignore the delimiter row on *both* read and write being quite confusing, but I've been a bit strapped for time recently and haven't been able to dive into this code gain. It works well, so let me know what you think.

The main thing that would really help readability for this is if we could (before any computation) just remove the delimiter row flat out. If you have a decent idea of an approach to do that, I'd love to know how. Alternatively, if you wanted to make any changes in my PR, I've granted you full permissions :)