### PR TITLE
Fixed issue where Markdown syntax would cause table columns to have incorrect lengths

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "ebnf": "1.9.0",
     "lodash": "4.17.20",
-    "meaw": "5.0.0"
+    "meaw": "5.0.0",
+    "remove-markdown": "^0.5.0"
   }
 }

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -4,6 +4,7 @@ import { Table } from './table';
 import { TableCell } from './table-cell';
 import { TableRow } from './table-row';
 import { getEAW } from 'meaw';
+const removeMd = require('remove-md');
 
 export interface FormattedTable {
   /**
@@ -209,8 +210,15 @@ export const _computeTextWidth = (
   text: string,
   options: TextWidthOptions,
 ): number => {
-  const normalized = options.normalize ? text.normalize('NFC') : text;
+  const unformattedText = removeMd(text);
+  const normalized = options.normalize
+    ? unformattedText.normalize('NFC')
+    : unformattedText;
   let w = 0;
+  // If text has inline link add 2 spaces to account for the link icon
+  if (/\[([^\]]*?)\][\[\(].*?[\]\)]/g.test(text)) {
+    w += 2;
+  }
   for (const char of normalized) {
     if (options.wideChars.has(char)) {
       w += 2;


### PR DESCRIPTION
The bug was described in this issue https://github.com/tgrosinger/advanced-tables-obsidian/issues/232 on the https://github.com/tgrosinger/advanced-tables-obsidian repository.

I've used the existing [remove-markdown](https://www.npmjs.com/package/remove-markdown) npm package but if the addition of extra packages is not desired it would be simple to reimplement as a private function as that package is just a single function with a series of regex commands.