### PR TITLE
Add duration support

### DIFF
--- a/docs/formulas.md
+++ b/docs/formulas.md
@@ -373,6 +373,7 @@ decimal points by using a formatting directive. For example:
 | 1   | 2   | 5   | 6   |
 | 3   | 4   | 7   | 8   |
 |     |     |     |     |
+
 <!-- TBLFM: @>=(@I / @3$4);%.2f -->
 ```
 
@@ -381,8 +382,9 @@ that, the results would be values such as `0.14285714285714285`, but because
 we have requested `2` decimal points, the results will instead be `0.14`.
 
 You may also output the result as a datetime with the `;dt` formatting
-directive. In this example, we take a datetime and add 600000 milliseconds, then
-output the result as a datetime.
+directive or as hours and minutes with the `;hm` formatting directive. In this
+example, we take a datetime and add 600000 milliseconds, then output the result
+as a datetime.
 
 ```
 | Start            | Ms     | End              |
@@ -395,19 +397,20 @@ output the result as a datetime.
 
 There is very basic support for operating on times in tables.
 
-Times are always represented as either a datetime string (2022-12-31 23:59), or
-as milliseconds since the epoch (1672559940000). When operating with durations,
-they must be expressed in milliseconds.
+Times are represented as either a datetime string (2022-12-31 23:59), or
+as milliseconds since the epoch (1672559940000). Durations may be expressed
+either as hours and minutes (23:59) or in milliseconds.
 
-For example, we can subtract an end time from a start time and view the duration
-in minutes:
+For example, we can subtract an end time from a start time and view the
+duration in milliseconds or as hours and minutes:
 
 ```
-| Start            | End              | Ms     | Min |
-| ---------------- | ---------------- | ------ | --- |
-| 2023-07-12 10:00 | 2023-07-12 10:10 | 600000 | 10  |
+| Start            | End              | Ms      | Mins | Duration |
+| ---------------- | ---------------- | ------- | ---- | -------- |
+| 2023-07-12 10:00 | 2023-07-12 12:10 | 7800000 | 130  | 02:10    |
 <!-- TBLFM: $3=($2 - $1) -->
-<!-- TBLFM: $4=($3 / 60000) -->
+<!-- TBLFM: $4=(($2 - $1) / 60000) -->
+<!-- TBLFM: $5=($2 - $1);hm -->
 ```
 
 ## Conclusion

--- a/docs/formulas.md
+++ b/docs/formulas.md
@@ -413,6 +413,28 @@ duration in milliseconds or as hours and minutes:
 <!-- TBLFM: $5=($2 - $1);hm -->
 ```
 
+Durations formatted as hours and minutes may also be used to represent a time
+of day.
+
+This next example shows a table someone might use to track time they spend on
+tasks. They fill in each task name along with task start and end times,
+optionally omitting a start time if it is the same as the previous tasks' end
+time. The formulas calculate the duration of each task, along with the total
+time spent on all tasks.
+
+```
+| Task        | Start |   End | Duration |
+| ----------- | ----- | -----:| --------:|
+| Plan day    | 09:00 | 09:15 |    00:15 |
+| Fix Bug#1   | 09:27 | 11:33 |    02:06 |
+| Fix Bug#2   |       | 12:22 |    00:49 |
+| Triage bugs | 13:00 | 17:00 |    04:00 |
+| Clean desk  |       | 17:30 |    00:30 |
+| **Total**   |       |       |    07:40 |
+<!-- TBLFM: $>=($3 - if($2>0, $2, @-1$3));hm -->
+<!-- TBLFM: @>$>=sum(@I..@-1);hm -->
+```
+
 ## Conclusion
 
 This documentation is a work in progress. Please help improve this

--- a/src/calc/calc.ts
+++ b/src/calc/calc.ts
@@ -57,9 +57,10 @@ algebraic_operation ::= "(" source " "? algebraic_operator " "? source ")"
 algebraic_operator  ::= "+" | "-" | "*" | "/"
 
 display_directive        ::= ";" display_directive_option
-display_directive_option ::= formatting_directive | datetime_directive
+display_directive_option ::= formatting_directive | datetime_directive | hourminute_directive
 formatting_directive     ::= "%." int "f"
-datetime_directive           ::= "dt"
+datetime_directive       ::= "dt"
+hourminute_directive     ::= "hm"
 
 float ::= "-"? int "." int
 real ::= "-"? int

--- a/src/calc/display_directive.ts
+++ b/src/calc/display_directive.ts
@@ -17,6 +17,7 @@ export class DefaultFormatter {
 export class DisplayDirective {
   private readonly decimalLength: number;
   private readonly displayAsDatetime: boolean;
+  private readonly displayAsHourMinute: boolean;
 
   constructor(ast: IToken) {
     let typeError = checkType(ast, 'display_directive');
@@ -47,13 +48,16 @@ export class DisplayDirective {
       formattingDirective,
       'formatting_directive',
       'datetime_directive',
+      'hourminute_directive',
     );
     if (typeError) {
       throw typeError;
     }
 
     this.displayAsDatetime = formattingDirective.type === 'datetime_directive';
-    if (this.displayAsDatetime) {
+    this.displayAsHourMinute =
+      formattingDirective.type === 'hourminute_directive';
+    if (this.displayAsDatetime || this.displayAsHourMinute) {
       this.decimalLength = -1;
       return;
     }
@@ -86,6 +90,15 @@ export class DisplayDirective {
       const h = pad(date.getHours());
       const min = pad(date.getMinutes());
       return `${y}-${mo}-${d} ${h}:${min}`;
+    }
+
+    if (this.displayAsHourMinute) {
+      let sign = parsed < 0 ? '-' : '';
+      const minutes = Math.floor(Math.abs(parsed) / 60000);
+      const pad = (v: number): string => `0${v}`.slice(-2);
+      const h = pad(Math.floor(minutes / 60));
+      const m = pad(minutes % 60);
+      return `${sign}${h}:${m}`;
     }
 
     return parsed.toFixed(this.decimalLength);

--- a/src/calc/results.ts
+++ b/src/calc/results.ts
@@ -5,6 +5,8 @@ const datetimeRe = new RegExp(
   '[1-9][0-9]{3}-[01][0-9]-[0-3][0-9][T ][0-2][0-9]:[0-5][0-9]',
 );
 
+const durationRe = new RegExp('^-?[0-9]+:[0-5][0-9]');
+
 export const FloatOrMilliseconds = (value: string): Decimal => {
   const v = value.trim();
   if (v === '') {
@@ -13,6 +15,13 @@ export const FloatOrMilliseconds = (value: string): Decimal => {
 
   if (datetimeRe.test(v)) {
     return new Decimal(new Date(v).valueOf());
+  }
+
+  if (durationRe.test(v)) {
+    const neg = v.charAt(0) == '-';
+    const w = v.slice(neg ? 1 : 0);
+    const minutes = parseInt(w.slice(0, -3)) * 60 + parseInt(w.slice(-2));
+    return new Decimal((neg ? -1 : 1) * minutes * 60000);
   }
 
   const decimalValue = new Decimal(v);

--- a/test/calc.ts
+++ b/test/calc.ts
@@ -2354,4 +2354,43 @@ describe('Formulas', () => {
       ]);
     }
   });
+
+  it('should correctly process a larger example', () => {
+    {
+      const textEditor = new TextEditor([
+        'foo',
+        '| Task             | Start |   End | Duration |',
+        '| ---------------- | ----- | -----:| --------:|',
+        '| Plan day         | 09:00 | 09:15 |          |',
+        '| Fix Bug#1        | 09:27 | 11:33 |          |',
+        '| Fix Bug#2        |       | 12:22 |          |',
+        '| Triage bugs      | 13:00 | 17:00 |          |',
+        '| Clean desk       |       | 17:30 |          |',
+        '| **Total**        |       |       |          |',
+        '<!-- TBLFM: $>=($3 - if($2>0, $2, @-1$3));hm -->',
+        '<!-- TBLFM: @>$>=sum(@I..@-1);hm -->',
+      ]);
+      textEditor.setCursorPosition(new Point(1, 0));
+      const tableEditor = new TableEditor(textEditor);
+      const err = tableEditor.evaluateFormulas(defaultOptions);
+      const pos = textEditor.getCursorPosition();
+      expect(err).to.be.undefined;
+      expect(pos.row).to.equal(1);
+      expect(pos.column).to.equal(0);
+      expect(textEditor.getSelectionRange()).to.be.undefined;
+      expect(textEditor.getLines()).to.deep.equal([
+        'foo',
+        '| Task        | Start |   End | Duration |',
+        '| ----------- | ----- | -----:| --------:|',
+        '| Plan day    | 09:00 | 09:15 |    00:15 |',
+        '| Fix Bug#1   | 09:27 | 11:33 |    02:06 |',
+        '| Fix Bug#2   |       | 12:22 |    00:49 |',
+        '| Triage bugs | 13:00 | 17:00 |    04:00 |',
+        '| Clean desk  |       | 17:30 |    00:30 |',
+        '| **Total**   |       |       |    07:40 |',
+        '<!-- TBLFM: $>=($3 - if($2>0, $2, @-1$3));hm -->',
+        '<!-- TBLFM: @>$>=sum(@I..@-1);hm -->',
+      ]);
+    }
+  });
 });


### PR DESCRIPTION
Hi! This is an implementation of a time of day / duration data type, somewhat similar to what was requested in #45.

It uses formatting directive ';hm' for hours and minutes. Org mode uses ';u'. ';hm' seems better to me because it matches ';dt', but I'd be happy enough with either ';hm' or ';u'.

