### PR TITLE
Implemented Reversed Indexing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,8 @@ module.exports = {
     sourceType: "module",
     project: ["./tsconfig.json"],
   },
+  "linebreak-style": ["off"],
+  "@typescript-eslint/quotes": ["error", "single", { "avoidEscape": true }],
   plugins: [
     "@typescript-eslint",
     "import",

--- a/docs/formulas.md
+++ b/docs/formulas.md
@@ -74,6 +74,8 @@ would mean "the same row, two columns right".
 
 When writing a cell reference, if the row or column portion is omitted, it means "in the current row" or "in the current column". In our example, `@I` and `@-1` have both omitted the column, so these references are for the same column as the destination cell.
 
+You can combine first and last arguments with a cell reference. `@>-1` and `$>-2` references the 2nd to last row and 3rd to last column, respectively. This is useful for referencing fixed points near the bottom of an expanding table. You can also reference 2nd to first row/columns with `@<+1` and `$<+1`, respectively.
+
 ### Ranges
 
 When writing `@2` by itself it means literally "row 2", as in, the entire

--- a/src/calc/calc.ts
+++ b/src/calc/calc.ts
@@ -42,8 +42,8 @@ relative_row ::= "@" ( "-" | "+" ) int
 relative_column ::= "$" ( "-" | "+" ) int
 
 absolute_reference ::= absolute_row absolute_column | absolute_row | absolute_column
-absolute_row ::= "@" ( "I" | "<" | ">" | int )
-absolute_column ::= "$" ( "<" | ">" | int )
+absolute_row ::= "@" ( "I" | ("<" | ">") (("+" | "-") int)? | int )
+absolute_column ::= "$" ( ("<" | ">") (("+" | "-") int)? | int )
 
 single_param_function_call ::= single_param_function "(" source ")" 
 single_param_function      ::= "mean" | "sum"

--- a/src/calc/column.ts
+++ b/src/calc/column.ts
@@ -76,7 +76,7 @@ export class AbsoluteColumn extends Column {
   constructor(ast: IToken, table: Table) {
     super();
 
-    let index = -1;
+    let index = 0;
     let symbol = '';
 
     switch (ast.children.length) {
@@ -89,6 +89,13 @@ export class AbsoluteColumn extends Column {
           throw err(typeError);
         }
         index = parseInt(ast.children[0].text);
+        // In the case of relative to first/last index ex: @>-3 
+        if (ast.text[1] === ">" || ast.text[1] === "<") {
+          symbol = ast.text[1];
+          if (ast.text[2] && ast.text[2] === "-") {
+            index *= -1;
+          }
+        }
         break;
       default:
         throw new Error(
@@ -101,10 +108,10 @@ export class AbsoluteColumn extends Column {
       case '':
         break;
       case '<':
-        index = 1;
+        index += 1;
         break;
       case '>':
-        index = table.getWidth();
+        index += table.getWidth();
         break;
       default:
         throw new Error(`Invalid column symbol '${symbol}'`);

--- a/src/calc/row.ts
+++ b/src/calc/row.ts
@@ -78,7 +78,7 @@ export class AbsoluteRow extends Row {
   constructor(ast: IToken, table: Table) {
     super();
 
-    let index = -1;
+    let index = 0;
     let symbol = '';
 
     switch (ast.children.length) {
@@ -91,6 +91,13 @@ export class AbsoluteRow extends Row {
           throw err(typeError);
         }
         index = parseInt(ast.children[0].text);
+        // In the case of relative to first/last index ex: @>-3 
+        if (ast.text[1] === ">" || ast.text[1] === "<") {
+          symbol = ast.text[1];
+          if (ast.text[2] && ast.text[2] === "-") {
+            index *= -1;
+          }
+        }        
         break;
       default:
         throw new Error(
@@ -103,10 +110,10 @@ export class AbsoluteRow extends Row {
       case '':
         break;
       case '<':
-        index = 1;
+        index += 1;
         break;
       case '>':
-        index = table.getHeight() - 1;
+        index += table.getHeight() - 1;
         break;
       case 'I':
         index = 2;

--- a/test/calc.ts
+++ b/test/calc.ts
@@ -237,6 +237,96 @@ describe('Formulas', () => {
           '| 3   | 4   |     |',
           '| 5   | 6   |     |',
           '|     |     |     |',
+          '<!-- TBLFM: $>-1=$1 -->',
+        ]);
+        textEditor.setCursorPosition(new Point(1, 0));
+        const tableEditor = new TableEditor(textEditor);
+        const err = tableEditor.evaluateFormulas(defaultOptions);
+        const pos = textEditor.getCursorPosition();
+        expect(err).to.be.undefined;
+        expect(pos.row).to.equal(1);
+        expect(pos.column).to.equal(0);
+        expect(textEditor.getSelectionRange()).to.be.undefined;
+        expect(textEditor.getLines()).to.deep.equal([
+          'foo',
+          '| A   | B   | C   |',
+          '| --- | --- | --- |',
+          '| 1   | 1   |     |',
+          '| 3   | 3   |     |',
+          '| 5   | 5   |     |',
+          '|     | 0   |     |',
+          '<!-- TBLFM: $>-1=$1 -->',
+        ]);
+      }
+      {
+        const textEditor = new TextEditor([
+          'foo',
+          '| A   | B   | C   |',
+          '| --- | --- | --- |',
+          '| 1   | 2   |     |',
+          '| 3   | 4   |     |',
+          '| 5   | 6   |     |',
+          '|     |     |     |',
+          '<!-- TBLFM: $3=$>-1 -->',
+        ]);
+        textEditor.setCursorPosition(new Point(1, 0));
+        const tableEditor = new TableEditor(textEditor);
+        const err = tableEditor.evaluateFormulas(defaultOptions);
+        const pos = textEditor.getCursorPosition();
+        expect(err).to.be.undefined;
+        expect(pos.row).to.equal(1);
+        expect(pos.column).to.equal(0);
+        expect(textEditor.getSelectionRange()).to.be.undefined;
+        expect(textEditor.getLines()).to.deep.equal([
+          'foo',
+          '| A   | B   | C   |',
+          '| --- | --- | --- |',
+          '| 1   | 2   | 2   |',
+          '| 3   | 4   | 4   |',
+          '| 5   | 6   | 6   |',
+          '|     |     | 0   |',
+          '<!-- TBLFM: $3=$>-1 -->',
+        ]);
+      }
+      {
+        const textEditor = new TextEditor([
+          'foo',
+          '| A   | B   | C   |',
+          '| --- | --- | --- |',
+          '| 1   | 2   |     |',
+          '| 3   | 4   |     |',
+          '| 5   | 6   |     |',
+          '|     |     |     |',
+          '<!-- TBLFM: $3=$>+1 -->',
+        ]);
+        textEditor.setCursorPosition(new Point(1, 0));
+        const tableEditor = new TableEditor(textEditor);
+        const err = tableEditor.evaluateFormulas(defaultOptions);
+        const pos = textEditor.getCursorPosition();
+        expect(err).to.be.undefined;
+        expect(pos.row).to.equal(1);
+        expect(pos.column).to.equal(0);
+        expect(textEditor.getSelectionRange()).to.be.undefined;
+        expect(textEditor.getLines()).to.deep.equal([
+          'foo',
+          '| A   | B   | C   |',
+          '| --- | --- | --- |',
+          '| 1   | 2   | 0   |',
+          '| 3   | 4   | 0   |',
+          '| 5   | 6   | 0   |',
+          '|     |     | 0   |',
+          '<!-- TBLFM: $3=$>+1 -->',
+        ]);
+      }
+      {
+        const textEditor = new TextEditor([
+          'foo',
+          '| A   | B   | C   |',
+          '| --- | --- | --- |',
+          '| 1   | 2   |     |',
+          '| 3   | 4   |     |',
+          '| 5   | 6   |     |',
+          '|     |     |     |',
           '<!-- TBLFM: @>$2=@2$1 -->',
         ]);
         textEditor.setCursorPosition(new Point(1, 0));
@@ -404,6 +494,34 @@ describe('Formulas', () => {
           '| 3   | 4   | 6   |',
           '| 5   | 6   | 10  |',
           '<!-- TBLFM: $3=(@0$1*2) -->',
+        ]);
+      }
+      {
+        const textEditor = new TextEditor([
+          'foo',
+          '| A   | B   | C   |',
+          '| --- | --- | --- |',
+          '| 1   | 2   |     |',
+          '| 3   | 4   |     |',
+          '| 5   | 6   |     |',
+          '<!-- TBLFM: $3=(@0$>-2*3) -->',
+        ]);
+        textEditor.setCursorPosition(new Point(1, 0));
+        const tableEditor = new TableEditor(textEditor);
+        const err = tableEditor.evaluateFormulas(defaultOptions);
+        const pos = textEditor.getCursorPosition();
+        expect(err).to.be.undefined;
+        expect(pos.row).to.equal(1);
+        expect(pos.column).to.equal(0);
+        expect(textEditor.getSelectionRange()).to.be.undefined;
+        expect(textEditor.getLines()).to.deep.equal([
+          'foo',
+          '| A   | B   | C   |',
+          '| --- | --- | --- |',
+          '| 1   | 2   | 3   |',
+          '| 3   | 4   | 9   |',
+          '| 5   | 6   | 15  |',
+          '<!-- TBLFM: $3=(@0$>-2*3) -->',
         ]);
       }
       {
@@ -1231,6 +1349,186 @@ describe('Formulas', () => {
           '<!-- TBLFM: @3$2..@>$3=$1 -->',
         ]);
       }
+      {
+        const textEditor = new TextEditor([
+          'foo',
+          '| A   | B   |',
+          '| --- | --- |',
+          '| 1   | 2   |',
+          '| 3   | 4   |',
+          '| 5   | 6   |',
+          '|     |     |',
+          '<!-- TBLFM: @>-1=@3 -->',
+        ]);
+        textEditor.setCursorPosition(new Point(1, 0));
+        const tableEditor = new TableEditor(textEditor);
+        const err = tableEditor.evaluateFormulas(defaultOptions);
+        const pos = textEditor.getCursorPosition();
+        expect(err).to.be.undefined;
+        expect(pos.row).to.equal(1);
+        expect(pos.column).to.equal(0);
+        expect(textEditor.getSelectionRange()).to.be.undefined;
+        expect(textEditor.getLines()).to.deep.equal([
+          'foo',
+          '| A   | B   |',
+          '| --- | --- |',
+          '| 1   | 2   |',
+          '| 3   | 4   |',
+          '| 3   | 4   |',
+          '|     |     |',
+          '<!-- TBLFM: @>-1=@3 -->',
+        ]);
+      }
+      {
+        const textEditor = new TextEditor([
+          'foo',
+          '| A   | B   |',
+          '| --- | --- |',
+          '| 1   | 2   |',
+          '| 3   | 4   |',
+          '| 5   | 6   |',
+          '|     |     |',
+          '<!-- TBLFM: @>-2=@3 -->',
+        ]);
+        textEditor.setCursorPosition(new Point(1, 0));
+        const tableEditor = new TableEditor(textEditor);
+        const err = tableEditor.evaluateFormulas(defaultOptions);
+        const pos = textEditor.getCursorPosition();
+        expect(err).to.be.undefined;
+        expect(pos.row).to.equal(1);
+        expect(pos.column).to.equal(0);
+        expect(textEditor.getSelectionRange()).to.be.undefined;
+        expect(textEditor.getLines()).to.deep.equal([
+          'foo',
+          '| A   | B   |',
+          '| --- | --- |',
+          '| 1   | 2   |',
+          '| 3   | 4   |',
+          '| 5   | 6   |',
+          '|     |     |',
+          '<!-- TBLFM: @>-2=@3 -->',
+        ]);
+      }
+      {
+        const textEditor = new TextEditor([
+          'foo',
+          '| A   | B   |',
+          '| --- | --- |',
+          '| 1   | 2   |',
+          '| 3   | 4   |',
+          '| 5   | 6   |',
+          '|     |     |',
+          '<!-- TBLFM: @<+2=@5 -->',
+        ]);
+        textEditor.setCursorPosition(new Point(1, 0));
+        const tableEditor = new TableEditor(textEditor);
+        const err = tableEditor.evaluateFormulas(defaultOptions);
+        const pos = textEditor.getCursorPosition();
+        expect(err).to.be.undefined;
+        expect(pos.row).to.equal(1);
+        expect(pos.column).to.equal(0);
+        expect(textEditor.getSelectionRange()).to.be.undefined;
+        expect(textEditor.getLines()).to.deep.equal([
+          'foo',
+          '| A   | B   |',
+          '| --- | --- |',
+          '| 1   | 2   |',
+          '| 0   | 0   |',
+          '| 5   | 6   |',
+          '|     |     |',
+          '<!-- TBLFM: @<+2=@5 -->',
+        ]);
+      }
+      {
+        const textEditor = new TextEditor([
+          'foo',
+          '| A   | B   |',
+          '| --- | --- |',
+          '| 1   | 2   |',
+          '| 3   | 4   |',
+          '| 5   | 6   |',
+          '|     |     |',
+          '<!-- TBLFM: @>$>-1=@2$1 -->',
+        ]);
+        textEditor.setCursorPosition(new Point(1, 0));
+        const tableEditor = new TableEditor(textEditor);
+        const err = tableEditor.evaluateFormulas(defaultOptions);
+        const pos = textEditor.getCursorPosition();
+        expect(err).to.be.undefined;
+        expect(pos.row).to.equal(1);
+        expect(pos.column).to.equal(0);
+        expect(textEditor.getSelectionRange()).to.be.undefined;
+        expect(textEditor.getLines()).to.deep.equal([
+          'foo',
+          '| A   | B   |',
+          '| --- | --- |',
+          '| 1   | 2   |',
+          '| 3   | 4   |',
+          '| 5   | 6   |',
+          '| 1   |     |',
+          '<!-- TBLFM: @>$>-1=@2$1 -->',
+        ]);
+      }
+      {
+        const textEditor = new TextEditor([
+          'foo',
+          '| A   | B   |',
+          '| --- | --- |',
+          '| 1   | 2   |',
+          '| 3   | 4   |',
+          '| 5   | 6   |',
+          '|     |     |',
+          '<!-- TBLFM: @>=@>-1 -->',
+        ]);
+        textEditor.setCursorPosition(new Point(1, 0));
+        const tableEditor = new TableEditor(textEditor);
+        const err = tableEditor.evaluateFormulas(defaultOptions);
+        const pos = textEditor.getCursorPosition();
+        expect(err).to.be.undefined;
+        expect(pos.row).to.equal(1);
+        expect(pos.column).to.equal(0);
+        expect(textEditor.getSelectionRange()).to.be.undefined;
+        expect(textEditor.getLines()).to.deep.equal([
+          'foo',
+          '| A   | B   |',
+          '| --- | --- |',
+          '| 1   | 2   |',
+          '| 3   | 4   |',
+          '| 5   | 6   |',
+          '| 5   | 6   |',
+          '<!-- TBLFM: @>=@>-1 -->',
+        ]);
+      }
+      {
+        const textEditor = new TextEditor([
+          'foo',
+          '| A   | B   |',
+          '| --- | --- |',
+          '| 1   | 2   |',
+          '| 3   | 4   |',
+          '| 5   | 6   |',
+          '|     |     |',
+          '<!-- TBLFM: @>-1$<+1=@<+1$>-1 -->',
+        ]);
+        textEditor.setCursorPosition(new Point(1, 0));
+        const tableEditor = new TableEditor(textEditor);
+        const err = tableEditor.evaluateFormulas(defaultOptions);
+        const pos = textEditor.getCursorPosition();
+        expect(err).to.be.undefined;
+        expect(pos.row).to.equal(1);
+        expect(pos.column).to.equal(0);
+        expect(textEditor.getSelectionRange()).to.be.undefined;
+        expect(textEditor.getLines()).to.deep.equal([
+          'foo',
+          '| A   | B   |',
+          '| --- | --- |',
+          '| 1   | 2   |',
+          '| 3   | 4   |',
+          '| 5   | 1   |',
+          '|     |     |',
+          '<!-- TBLFM: @>-1$<+1=@<+1$>-1 -->',
+        ]);
+      }
     });
 
     it('should handle conditional functions', () => {
@@ -1859,6 +2157,41 @@ describe('Formulas', () => {
           '| 5   | 6   |     |',
           '|     |     |     |',
           '<!-- TBLFM: @-1=@2 -->',
+        ]);
+      }
+      {
+        const textEditor = new TextEditor([
+          'foo',
+          '| A   | B   | C   |',
+          '| --- | --- | --- |',
+          '| 1   | 2   |     |',
+          '| 4   | 3   |     |',
+          '| 5   | 6   |     |',
+          '|     |     |     |',
+          '<!-- TBLFM: @<-1=@2 -->',
+        ]);
+        textEditor.setCursorPosition(new Point(1, 0));
+        const tableEditor = new TableEditor(textEditor);
+        const err = tableEditor.evaluateFormulas(defaultOptions);
+        const pos = textEditor.getCursorPosition();
+        if (!err) {
+          assert.fail();
+        }
+        expect(err.message).to.equal(
+          `Index 0 may not be used in a destination`,
+        );
+        expect(pos.row).to.equal(1);
+        expect(pos.column).to.equal(0);
+        expect(textEditor.getSelectionRange()).to.be.undefined;
+        expect(textEditor.getLines()).to.deep.equal([
+          'foo',
+          '| A   | B   | C   |',
+          '| --- | --- | --- |',
+          '| 1   | 2   |     |',
+          '| 4   | 3   |     |',
+          '| 5   | 6   |     |',
+          '|     |     |     |',
+          '<!-- TBLFM: @<-1=@2 -->',
         ]);
       }
       {


### PR DESCRIPTION
Added the ability to reference cells relative to the bottom of the table.

I ran into an issue where I wanted to have a total and total after tax listed at the bottom of a table, but found no way to do this. I saw another user had a similar issue and submitted a feature request so I decided to give it a go! (https://github.com/tgrosinger/advanced-tables-obsidian/issues/334)

This works through the first '<' and last '>' argument combined with relative indexing ('+n' or '-n')

ex: @>-1 references the 2nd to last row and $>-2 references the 3rd to last column.

This also works with 2nd to first row and column: @<+2 and $<+1

I added test cases for these and functionality seems correct, but I'm not 100% sure that I tested all the scenarios.

Updated the formulas.md.

I slightly changed the functionality of the row and column classes. The index now starts at 0 instead of -1 and the switch case now adds the appropriate values to index. This allows index be changed relatively then add the absolute value.

I had to change .eslintrc.js to get it to run for me as I am on a windows machine and it probably needs reverted. Sorry if this (or anything else) isn't standard practice, this is my first contribution to a public GitHub.