### PR TITLE
fix: duration overflow [#93]

### DIFF
--- a/src/calc/display_directive.ts
+++ b/src/calc/display_directive.ts
@@ -1,4 +1,5 @@
 import { checkChildLength, checkType } from './ast_utils';
+import { padStart } from 'lodash';
 import { IToken } from 'ebnf';
 
 export interface Formatter {
@@ -79,11 +80,11 @@ export class DisplayDirective {
 
   public format = (num: number | string): string => {
     const parsed = typeof num === 'string' ? parseFloat(num) : num;
+    const pad = (v: number): string => padStart(`${v}`, 2, '0');
 
     if (this.displayAsDatetime) {
       // Seriously, there's no date formatting functionality in Javascript?
       const date = new Date(parsed);
-      const pad = (v: number): string => `0${v}`.slice(-2);
       const y = date.getFullYear();
       const mo = pad(date.getMonth() + 1);
       const d = pad(date.getDate());
@@ -95,7 +96,6 @@ export class DisplayDirective {
     if (this.displayAsHourMinute) {
       let sign = parsed < 0 ? '-' : '';
       const minutes = Math.floor(Math.abs(parsed) / 60000);
-      const pad = (v: number): string => `0${v}`.slice(-2);
       const h = pad(Math.floor(minutes / 60));
       const m = pad(minutes % 60);
       return `${sign}${h}:${m}`;

--- a/src/calc/display_directive.ts
+++ b/src/calc/display_directive.ts
@@ -94,7 +94,7 @@ export class DisplayDirective {
     }
 
     if (this.displayAsHourMinute) {
-      let sign = parsed < 0 ? '-' : '';
+      const sign = parsed < 0 ? '-' : '';
       const minutes = Math.floor(Math.abs(parsed) / 60000);
       const h = pad(Math.floor(minutes / 60));
       const m = pad(minutes % 60);

--- a/test/calc.ts
+++ b/test/calc.ts
@@ -629,6 +629,68 @@ describe('Formulas', () => {
       }
     });
 
+    it('should handle durations over 99:59', () => {
+      {
+        const textEditor = new TextEditor([
+          'foo',
+          '| Duration |',
+          '| -------- |',
+          '| 99:00    |',
+          '| 1:00     |',
+          '|          |',
+          '<!-- TBLFM: @>$>=sum(@I..@-1);hm -->',
+        ]);
+        textEditor.setCursorPosition(new Point(1, 0));
+        const tableEditor = new TableEditor(textEditor);
+        const err = tableEditor.evaluateFormulas(defaultOptions);
+        const pos = textEditor.getCursorPosition();
+        expect(err).to.be.undefined;
+        expect(pos.row).to.equal(1);
+        expect(pos.column).to.equal(0);
+        expect(textEditor.getSelectionRange()).to.be.undefined;
+        expect(textEditor.getLines()).to.deep.equal([
+          'foo',
+          '| Duration |',
+          '| -------- |',
+          '| 99:00    |',
+          '| 1:00     |',
+          '| 100:00   |',
+          '<!-- TBLFM: @>$>=sum(@I..@-1);hm -->',
+        ]);
+      }
+    });
+
+    it('should handle durations under -99:59', () => {
+      {
+        const textEditor = new TextEditor([
+          'foo',
+          '| Duration |',
+          '| -------- |',
+          '| -99:00   |',
+          '| -1:00    |',
+          '|          |',
+          '<!-- TBLFM: @>$>=sum(@I..@-1);hm -->',
+        ]);
+        textEditor.setCursorPosition(new Point(1, 0));
+        const tableEditor = new TableEditor(textEditor);
+        const err = tableEditor.evaluateFormulas(defaultOptions);
+        const pos = textEditor.getCursorPosition();
+        expect(err).to.be.undefined;
+        expect(pos.row).to.equal(1);
+        expect(pos.column).to.equal(0);
+        expect(textEditor.getSelectionRange()).to.be.undefined;
+        expect(textEditor.getLines()).to.deep.equal([
+          'foo',
+          '| Duration |',
+          '| -------- |',
+          '| -99:00   |',
+          '| -1:00    |',
+          '| -100:00  |',
+          '<!-- TBLFM: @>$>=sum(@I..@-1);hm -->',
+        ]);
+      }
+    });
+
     it('should not have floating point arithmetic errors', () => {
       {
         const textEditor = new TextEditor([


### PR DESCRIPTION
Time formatting was not correctly handling durations over 99:59 (or
durations less than -99:59) because `pad` was too keen on keeping the
string 2 characters long. Replaced it with `padStart` from `lodash`.

Fixes #93.
